### PR TITLE
Update log messages of tgenv-exec to debug

### DIFF
--- a/libexec/helpers
+++ b/libexec/helpers
@@ -13,6 +13,12 @@ function info() {
   echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
 }
 
+function debug() {
+  if [ -n "${TGENV_DEBUG}" ]; then
+    echo -e "\033[0;34m[DEBUG] ${1}\033[0;39m"
+  fi
+}
+
 # Curl wrapper to switch TLS option for each OS
 function curlw () {
   local TLS_OPT="--tlsv1.2"

--- a/libexec/tgenv-exec
+++ b/libexec/tgenv-exec
@@ -17,9 +17,9 @@ set -e
 [ -n "${TGENV_DEBUG}" ] && set -x
 source "${TGENV_ROOT}/libexec/helpers"
 
-info 'Getting version from tgenv-version-name';
+debug 'Getting version from tgenv-version-name';
 TGENV_VERSION="$(tgenv-version-name)" \
-  && info "TGENV_VERSION is ${TGENV_VERSION}" \
+  && debug "TGENV_VERSION is ${TGENV_VERSION}" \
   || {
     # Errors will be logged from tgenv-version name,
     # we don't need to trouble STDERR with repeat information here


### PR DESCRIPTION
## Why? 🤔

This PR will update the log level of the default messages of `tgenv-exec` to debug. This proposal is to keep the output of the command to be consistent to what we should expect from `terragrunt`. Without this change it's impossible to use `terragrunt output -json` piping it's contents to another command.

Below is the example of what was before and now:

#### Before
```
$ terragrunt output -json
[INFO] Getting version from tgenv-version-name
[INFO] TGENV_VERSION is 0.42.5
{
  "queue": {
    "sensitive": false,
    "type": [
      "object",
      {
        "this_sqs_queue_arn": "string",
        "this_sqs_queue_id": "string",
        "this_sqs_queue_name": "string"
      }
    ],
    "value": {
      "this_sqs_queue_arn": "arn:aws:sqs:us-east-2:000000000000:queue",
      "this_sqs_queue_id": "https://sqs.us-east-2.amazonaws.com/000000000000/queue",
      "this_sqs_queue_name": "queue"
    }
  }
}
```

#### After
```
$ terragrunt output -json
{
  "queue": {
    "sensitive": false,
    "type": [
      "object",
      {
        "this_sqs_queue_arn": "string",
        "this_sqs_queue_id": "string",
        "this_sqs_queue_name": "string"
      }
    ],
    "value": {
      "this_sqs_queue_arn": "arn:aws:sqs:us-east-2:000000000000:queue",
      "this_sqs_queue_id": "https://sqs.us-east-2.amazonaws.com/000000000000/queue",
      "this_sqs_queue_name": "queue"
    }
  }
}
```

## What? :hammer_and_wrench:

This PR:
1) adds a new log message type `debug`, which is only displayed if `TGENV_DEBUG` is set
2) changes two log messages from `tgenv-exec` to use this new log message helper

## Additional Links 🌐

- None
