### PR TITLE
Add installation support to Macbook M1

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -37,7 +37,16 @@ if [ -f "${dst_path}/terragrunt" ]; then
   exit 0
 fi
 
-TGENV_ARCH="${TGENV_ARCH:-amd64}"
+# Add support of ARM64 for Linux & Apple Silicon
+case "$(uname -m)" in
+  aarch64* | arm64*)
+    TGENV_ARCH="${TGENV_ARCH:-arm64}";
+    ;;
+  *)
+    TGENV_ARCH="${TGENV_ARCH:-amd64}";
+    ;;
+esac;
+
 case "$(uname -s)" in
   Darwin*)
     os="darwin_${TGENV_ARCH}"


### PR DESCRIPTION
## Why? 🤔

Include support to installs at new processor chip arm of the Apple `M1`. Actually I don't have a Macbook with this processor arch, so I need help to test this.

## What? :hammer_and_wrench:

- `libexec/tgenv-install`: Include a new `case` check condition.

## Additional Links 🌐

- Original Pull Request: [cunymatthieu/tgenv/pull/35](https://github.com/cunymatthieu/tgenv/pull/35)


