### PR TITLE
Restore tgenv list-remote output order to desc

### DIFF
--- a/libexec/tgenv-list-remote
+++ b/libexec/tgenv-list-remote
@@ -13,7 +13,7 @@ git ls-remote --tags https://github.com/gruntwork-io/terragrunt \
   | awk '{ print $2 }' \
   | cut -d "/" -f 3 \
   | sed 's/v//' \
-  | sort -V
+  | sort -Vr
 return_code=$?
 
 if [ $return_code != 0 ];then


### PR DESCRIPTION
## Why? 🤔

I broke this in https://github.com/tgenv/tgenv/pull/2. Original behaviour was to list versions in desc order as per the README. PR#2 inadvertently reversed that to ascending order. That also broke `tgenv install` when used with `latest` keyword.

Expected Behaviour

```
% tgenv list-remote
0.42.5
0.42.4
0.42.3
0.42.2
0.42.1
0.42.0
0.41.0
0.40.2
0.40.1
0.40.0
0.39.2
0.39.1
0.39.0
```

```bash
➜  .tgenv git:(main) ✗ tgenv install latest  
[INFO] Installing Terragrunt v0.42.5
[INFO] Downloading release tarball from https://github.com/gruntwork-io/terragrunt/releases/download/v0.42.5/terragrunt_darwin_amd64
########################################################################################################################################################################################################### 100.0%
[INFO] Installation of terragrunt v0.42.5 successful
[INFO] Switching to v0.42.5
[INFO] Switching completed
```

Actual Behaviour

```
➜  .tgenv git:(main) ✗ tgenv list-remote 
0.0.1
0.0.2
0.0.3
0.0.4
0.0.5
0.0.6
0.0.7
0.0.8
0.0.9
```

```bash
➜  .tgenv git:(main) ✗ tgenv install latest 
[INFO] Installing Terragrunt v0.0.1
[INFO] Downloading release tarball from https://github.com/gruntwork-io/terragrunt/releases/download/v0.0.1/terragrunt_darwin_amd64
curl: (22) The requested URL returned error: 404                                                                                                                                                                 

tgenv: tgenv-install: [ERROR] Tarball download failed
```

## What? :hammer_and_wrench:

This change restores `tgenv list-remote` to listing versions in descending order.

## Additional Links 🌐

 * https://github.com/tgenv/tgenv/pull/2

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets -->