### PR TITLE
Set TGENV_AUTO_INSTALL default value as true

### DIFF
--- a/libexec/tgenv-exec
+++ b/libexec/tgenv-exec
@@ -28,7 +28,7 @@ TGENV_VERSION="$(tgenv-version-name)" \
 export TGENV_VERSION;
 
 if [ ! -d "${TGENV_ROOT}/versions/${TGENV_VERSION}" ]; then
-  if [ "${TGENV_AUTO_INSTALL:-false}" == "true" ]; then
+  if [ "${TGENV_AUTO_INSTALL:-true}" == "true" ]; then
     info "version '${TGENV_VERSION}' is not installed (set by $(tgenv-version-file)). Installing now as TGENV_AUTO_INSTALL==true";
     tgenv-install;
   else


### PR DESCRIPTION
## Why? 🤔

https://github.com/cunymatthieu/tgenv/issues/39 raised the issue that the default value of `TGENV_AUTO_INSTALL` is inconsistent with the tgenv documentation

 * Documentation: https://github.com/tgenv/tgenv/blob/89692a51a2c46e77c2a4c79fe9c06d50fe413b3a/README.md?plain=1#L131-L133
 * Implementation: https://github.com/tgenv/tgenv/blob/89692a51a2c46e77c2a4c79fe9c06d50fe413b3a/libexec/tgenv-exec#L31
 
Note that the default behaviour of tfenv is also `TFENV_AUTO_INSTALL=true` by default
 
 * https://github.com/tfutils/tfenv/blob/master/lib/tfenv-exec.sh#L25
 
## What? :hammer_and_wrench:

This PR changes the default value of `TGENV_AUTO_INSTALL` from `false` to `true`

**Old Behaviour**

Default

```bash
➜  ~ terragrunt help               
tgenv: tgenv-version-name: [WARN] version '0.30.2' is not installed (set by /Users/simon/.terragrunt-version)
tgenv: tgenv-exec: [ERROR] version '0.30.2' was requested, but not installed and TGENV_AUTO_INSTALL is not 'true'
```

Override default with environment variable.

```bash
➜  ~ TGENV_AUTO_INSTALL=true terragrunt help
tgenv: tgenv-version-name: [WARN] version '0.30.3' is not installed (set by /Users/simon/.terragrunt-version)
[INFO] version '0.30.3' is not installed (set by /Users/simon/.terragrunt-version). Installing now as TGENV_AUTO_INSTALL==true
[INFO] Installing Terragrunt v0.30.3
[INFO] Downloading release tarball from https://github.com/gruntwork-io/terragrunt/releases/download/v0.30.3/terragrunt_darwin_arm64
#################################################################################################################################################################################################### 100.0%
[INFO] Installation of terragrunt v0.30.3 successful
[INFO] Switching to v0.30.3
[INFO] Switching completed
```

**New Behaviour**

Default

```bash
➜  ~ terragrunt help 
tgenv: tgenv-version-name: [WARN] version '0.30.1' is not installed (set by /Users/simon/.terragrunt-version)
[INFO] version '0.30.1' is not installed (set by /Users/simon/.terragrunt-version). Installing now as TGENV_AUTO_INSTALL==true
[INFO] Installing Terragrunt v0.30.1
[INFO] Downloading release tarball from https://github.com/gruntwork-io/terragrunt/releases/download/v0.30.1/terragrunt_darwin_arm64
#################################################################################################################################################################################################### 100.0%
[INFO] Installation of terragrunt v0.30.1 successful
[INFO] Switching to v0.30.1
[INFO] Switching completed
```

Override default
```
➜  ~ TGENV_AUTO_INSTALL=false terragrunt help
tgenv: tgenv-version-name: [WARN] version '0.30.5' is not installed (set by /Users/simon/.terragrunt-version)
tgenv: tgenv-exec: [ERROR] version '0.30.5' was requested, but not installed and TGENV_AUTO_INSTALL is not 'true'
```

## Additional Links 🌐

 * https://github.com/cunymatthieu/tgenv/issues/39

 
<!-- Add any relevant links here, eg. to other pull requests or Jira tickets -->


