### PR TITLE
Disable colored output if -no-color flag used with terragrunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ Set the debug level for TGENV.
 * unset/empty-string: No debug output
 * set: Bash execution tracing
 
+#### `TGENV_DISABLE_COLOR`
+
+Integer (Default: "")
+
+Disable colored output for tgenv. This variable can either be set explicitly or will be set
+automatically if the `-no-color` flag is used with the terragrunt binary.
+
 ## Uninstalling :no_entry_sign:
 
 Just run:

--- a/bin/terragrunt
+++ b/bin/terragrunt
@@ -3,4 +3,14 @@ set -e
 [ -n "${TGENV_DEBUG}" ] && set -x
 
 program="${0##*/}"
+
+NO_COLOR=0
+for arg in "$@"; do
+  if [ "$arg" = "-no-color" ]; then
+    NO_COLOR=1
+    break
+  fi
+done
+export NO_COLOR
+
 exec "$(dirname "$(command -v "${0}")")/tgenv" exec "${@}"

--- a/bin/terragrunt
+++ b/bin/terragrunt
@@ -4,13 +4,12 @@ set -e
 
 program="${0##*/}"
 
-NO_COLOR=0
+export TGENV_DISABLE_COLOR=${TGENV_DISABLE_COLOR:-0}
 for arg in "$@"; do
-  if [ "$arg" = "-no-color" ]; then
-    NO_COLOR=1
-    break
-  fi
+    if [ "$arg" = "-no-color" ]; then
+        export TGENV_DISABLE_COLOR=1
+        break
+    fi
 done
-export NO_COLOR
 
 exec "$(dirname "$(command -v "${0}")")/tgenv" exec "${@}"

--- a/bin/terragrunt
+++ b/bin/terragrunt
@@ -6,10 +6,10 @@ program="${0##*/}"
 
 export TGENV_DISABLE_COLOR=${TGENV_DISABLE_COLOR:-0}
 for arg in "$@"; do
-    if [ "$arg" = "-no-color" ]; then
-        export TGENV_DISABLE_COLOR=1
-        break
-    fi
+  if [ "$arg" = "-no-color" ]; then
+    export TGENV_DISABLE_COLOR=1
+    break
+  fi
 done
 
 exec "$(dirname "$(command -v "${0}")")/tgenv" exec "${@}"

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -5,22 +5,46 @@ function error_and_proceed() {
   echo -e "tgenv: ${0}: Test Failed: ${1}" >&2
 }
 
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+BLUE="\033[0;34m"
+RESET="\033[0;39m"
+
+# export NO_COLOR=1
+
 function error_and_die() {
-  echo -e "tgenv: $(basename ${0}): \033[0;31m[ERROR] ${1}\033[0;39m" >&2
+  if [ "$NO_COLOR" -eq 1 ]; then
+    echo -e "tgenv: $(basename ${0}): [ERROR] ${1}" >&2
+  else
+    echo -e "tgenv: $(basename ${0}): ${BLUE}[ERROR] ${1}${RESET}" >&2
+  fi
   exit 1
 }
 
 function warn_and_continue() {
-  echo -e "tgenv: $(basename ${0}): \033[0;33m[WARN] ${1}\033[0;39m" >&2
+  if [ "$NO_COLOR" -eq 1 ]; then
+    echo -e "tgenv: $(basename ${0}): [WARN] ${1}" >&2
+  else
+    echo -e "tgenv: $(basename ${0}): ${YELLOW}[WARN] ${1}${RESET}" >&2
+  fi
 }
 
 function info() {
-  echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
+  if [ "$NO_COLOR" -eq 1 ]; then
+    echo "[INFO] $1"
+  else
+    echo -e "${GREEN}[INFO] $1${RESET}"
+  fi
 }
 
 function debug() {
   if [ -n "${TGENV_DEBUG}" ]; then
-    echo -e "\033[0;34m[DEBUG] ${1}\033[0;39m"
+    if [[ "${NO_COLOR}" -eq 1 ]]; then
+      echo -e "[DEBUG] ${1}"
+    else
+      echo -e "${BLUE}[DEBUG] ${1}${RESET}"
+    fi
   fi
 }
 

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -13,7 +13,7 @@ RESET="\033[0;39m"
 
 
 function error_and_die() {
-  if [ "$TGENV_DISABLE_COLOR" -eq 1 ]; then
+  if [[ "$TGENV_DISABLE_COLOR" -eq 1 ]]; then
     echo -e "tgenv: $(basename ${0}): [ERROR] ${1}" >&2
   else
     echo -e "tgenv: $(basename ${0}): ${RED}[ERROR] ${1}${RESET}" >&2
@@ -22,7 +22,7 @@ function error_and_die() {
 }
 
 function warn_and_continue() {
-  if [ "${TGENV_DISABLE_COLOR}" -eq 1 ]; then
+  if [[ "${TGENV_DISABLE_COLOR}" -eq 1 ]]; then
     echo -e "tgenv: $(basename ${0}): [WARN] ${1}" >&2
   else
     echo -e "tgenv: $(basename ${0}): ${YELLOW}[WARN] ${1}${RESET}" >&2
@@ -30,7 +30,7 @@ function warn_and_continue() {
 }
 
 function info() {
-  if [ "${TGENV_DISABLE_COLOR}" -eq 1 ]; then
+  if [[ "${TGENV_DISABLE_COLOR}" -eq 1 ]]; then
     echo "[INFO] $1"
   else
     echo -e "${GREEN}[INFO] $1${RESET}"
@@ -38,7 +38,7 @@ function info() {
 }
 
 function debug() {
-  if [ -n "${TGENV_DEBUG}" ]; then
+  if [[ -n "${TGENV_DEBUG}" ]]; then
     if [[ "${TGENV_DISABLE_COLOR}" -eq 1 ]]; then
       echo -e "[DEBUG] ${1}"
     else

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -5,6 +5,7 @@ function error_and_proceed() {
   echo -e "tgenv: ${0}: Test Failed: ${1}" >&2
 }
 
+# https://dev.to/ifenna__/adding-colors-to-bash-scripts-48g4
 RED="\033[0;31m"
 GREEN="\033[0;32m"
 YELLOW="\033[0;33m"

--- a/libexec/helpers
+++ b/libexec/helpers
@@ -11,19 +11,18 @@ YELLOW="\033[0;33m"
 BLUE="\033[0;34m"
 RESET="\033[0;39m"
 
-# export NO_COLOR=1
 
 function error_and_die() {
-  if [ "$NO_COLOR" -eq 1 ]; then
+  if [ "$TGENV_DISABLE_COLOR" -eq 1 ]; then
     echo -e "tgenv: $(basename ${0}): [ERROR] ${1}" >&2
   else
-    echo -e "tgenv: $(basename ${0}): ${BLUE}[ERROR] ${1}${RESET}" >&2
+    echo -e "tgenv: $(basename ${0}): ${RED}[ERROR] ${1}${RESET}" >&2
   fi
   exit 1
 }
 
 function warn_and_continue() {
-  if [ "$NO_COLOR" -eq 1 ]; then
+  if [ "${TGENV_DISABLE_COLOR}" -eq 1 ]; then
     echo -e "tgenv: $(basename ${0}): [WARN] ${1}" >&2
   else
     echo -e "tgenv: $(basename ${0}): ${YELLOW}[WARN] ${1}${RESET}" >&2
@@ -31,7 +30,7 @@ function warn_and_continue() {
 }
 
 function info() {
-  if [ "$NO_COLOR" -eq 1 ]; then
+  if [ "${TGENV_DISABLE_COLOR}" -eq 1 ]; then
     echo "[INFO] $1"
   else
     echo -e "${GREEN}[INFO] $1${RESET}"
@@ -40,7 +39,7 @@ function info() {
 
 function debug() {
   if [ -n "${TGENV_DEBUG}" ]; then
-    if [[ "${NO_COLOR}" -eq 1 ]]; then
+    if [[ "${TGENV_DISABLE_COLOR}" -eq 1 ]]; then
       echo -e "[DEBUG] ${1}"
     else
       echo -e "${BLUE}[DEBUG] ${1}${RESET}"

--- a/libexec/tgenv-uninstall
+++ b/libexec/tgenv-uninstall
@@ -35,5 +35,5 @@ dst_path="${TGENV_ROOT}/versions/${version}"
 if [ -f "${dst_path}/terragrunt" ]; then 
   info "Uninstall Terragrunt v${version}"
   rm -r "${dst_path}"
-  info "\033[0;32mTerragrunt v${version} is successfully uninstalled\033[0;39m"
+  info "Terragrunt v${version} is successfully uninstalled"
 fi


### PR DESCRIPTION
## Why? 🤔

Fixes: https://github.com/tgenv/tgenv/issues/22

## What? :hammer_and_wrench:

 1. Checks if the `-no-color` flag was passed to terragrunt and sets a NO_COLOR flag for tgenv
 2. Implements output without color.

## Additional Links 🌐

https://github.com/tgenv/tgenv/issues/22
