### PR TITLE
Allow installing the version specified in ${TGENV_ROOT}/version

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -9,9 +9,7 @@ declare version_requested version regex
 
 if [ -z "${1}" ]; then
   version_file="$(tgenv-version-file)"
-  if [ "${version_file}" != "${TGENV_ROOT}/version" ]; then
-    version_requested="$(cat "${version_file}" || true)"
-  fi
+  version_requested="$(cat "${version_file}" || true)"
 else
   version_requested="${1}"
 fi


### PR DESCRIPTION
## Why? 🤔

Although a default version *can* be specified in `${TGENV_ROOT}/.terragrunt-version`, there is also *partial* support for specifying a version in `${TGENV_ROOT}/version`, similar to [tfenv](https://github.com/tfutils/tfenv?tab=readme-ov-file#tfenv-list).

However, when only `${TGENV_ROOT}/version` is present to specify the global default version of Terragrunt:

```console
$ terragrunt version
tgenv: tgenv-version-name: [WARN] version '0.82.2' is not installed (set by /opt/tgenv/version)
[INFO] version '0.82.2' is not installed (set by /opt/tgenv/version). Installing now as TGENV_AUTO_INSTALL==true
tgenv: tgenv-install: [ERROR] Version is not specified
```

## What? :hammer_and_wrench:

This change allows reading the requested version from `${TGENV_ROOT}/version` or whichever `.terragrunt-version` file was found by `tgenv-version-file`:

```console
$ terragrunt version
tgenv: tgenv-version-name: [WARN] version '0.82.2' is not installed (set by /opt/tgenv/version)
[INFO] version '0.82.2' is not installed (set by /opt/tgenv/version). Installing now as TGENV_AUTO_INSTALL==true
[INFO] Installing Terragrunt v0.82.2
[INFO] Downloading release tarball from https://github.com/gruntwork-io/terragrunt/releases/download/v0.82.2/terragrunt_linux_arm64
...
[INFO] Installation of terragrunt v0.82.2 successful
[INFO] Switching to v0.82.2
[INFO] Switching completed
...
```

## Additional Links 🌐

- [Resolving the requested version in tfenv](https://github.com/tfutils/tfenv/blob/c8eb402135bf6fbcd2809f6cdbf7ea1113de6e54/libexec/tfenv-resolve-version#L74-L104)


