### PR TITLE
Fix #45: List only full release versions.

### DIFF
--- a/libexec/tgenv-list-remote
+++ b/libexec/tgenv-list-remote
@@ -15,6 +15,7 @@ git ls-remote --tags https://github.com/gruntwork-io/terragrunt \
   | awk '{ print $2 }' \
   | cut -d "/" -f 3 \
   | sed 's/v//' \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
   | sort -Vr \
   | tee "${tmp_list_all_versions_offline}"
 return_code=$?


### PR DESCRIPTION
## Why? 🤔

[Terragrunt does not include binaries for pre-releases](https://github.com/gruntwork-io/terragrunt/issues/4917), so when using `tgenv install latest` when the latest is a pre-release, the installation fails. This also goes for attempting to install a pre-release specifically - the assets aren't found so the installation fails.

## What? :hammer_and_wrench:

Updated the `tgenv list-remote` functionality to only show versions that do not have pre-release indicators - they must match a full semantic version (X.Y.Z, not X.Y.Z-pre or similar - no suffixes).

## Additional Links 🌐

[Issue with Terragrunt asking for clarification of their release process](https://github.com/gruntwork-io/terragrunt/issues/4917), which indicates they intentionally do not provide pre-release binaries.


