### PR TITLE
patch(version): From ustuehler:patch-1 - Ajustments for versions

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -9,9 +9,7 @@ declare version_requested version regex
 
 if [ -z "${1}" ]; then
   version_file="$(tgenv-version-file)"
-  if [ "${version_file}" != "${TGENV_ROOT}/version" ]; then
-    version_requested="$(cat "${version_file}" || true)"
-  fi
+  version_requested="$(cat "${version_file}" || true)"
 else
   version_requested="${1}"
 fi

--- a/libexec/tgenv-use
+++ b/libexec/tgenv-use
@@ -8,10 +8,9 @@ declare version_requested version regex
 if [ -z "${1}" ]; then
   info "Version not specified, looking for version file"
   version_file="$(tgenv-version-file)"
-  if [ "${version_file}" != "${TGENV_ROOT}/version" ]; then
-    version_requested="$(cat "${version_file}" || true)"
-  else
-    info "Version file not found, using latest"
+  version_requested="$(cat "${version_file}" || true)"
+  if [ -z "${version_requested}" ]; then
+    info "Version file not found or empty, using latest"
     version_requested="latest"
   fi
 else

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -87,6 +87,26 @@ echo "latest:^0.38" > ./.terragrunt-version
 ) || error_and_proceed "Installing .terragrunt-version ${v}"
 
 ##################################################
+# Test install from ${TGENV_ROOT}/version (global version file)
+##################################################
+echo "### Install specific version from \${TGENV_ROOT}/version"
+cleanup || error_and_die "Cleanup failed?!"
+
+v=0.36.1
+_global_version_file="${TGENV_ROOT}/version"
+_global_version_backup="$(cat "${_global_version_file}" 2>/dev/null || true)"
+echo "${v}" > "${_global_version_file}"
+(
+  tgenv install || exit 1
+  check_version "${v}" || exit 1
+) || error_and_proceed "Installing version from \${TGENV_ROOT}/version ${v}"
+if [ -n "${_global_version_backup}" ]; then
+  echo "${_global_version_backup}" > "${_global_version_file}"
+else
+  rm -f "${_global_version_file}"
+fi
+
+##################################################
 # Install invalid specific version .terragrunt-version
 ##################################################
 echo "### Install invalid specific version .terragrunt-version"


### PR DESCRIPTION
 ## What
 
 This PR implements and extends the fix originally proposed in #44.
 
 When `tgenv install` is called without arguments and no `.terragrunt-version`
 file exists locally or in `$HOME`, tgenv falls back to `${TGENV_ROOT}/version`
 as the version source — but the version was silently ignored, causing the error:
 

tgenv-install: [ERROR] Version is not specified

 
 ## Changes
 
 - **`libexec/tgenv-install`**: removed the guard that prevented reading from
   `${TGENV_ROOT}/version`, so `tgenv install` now respects the global version file
 - **`libexec/tgenv-use`**: aligned with the same behavior — now reads
   `${TGENV_ROOT}/version` when no local version file is found; falls back to
   `latest` only when the file is absent or empty
 - **`test/test_install_and_use.sh`**: added test case covering `tgenv install`
   reading from `${TGENV_ROOT}/version`
 
 ## Notes
 
 Credit to @ustuehler for the original fix in #44.
 
 Closes #44


