### PR TITLE
Fixing tgenv/tgenv#47

### DIFF
--- a/libexec/tgenv-use
+++ b/libexec/tgenv-use
@@ -29,16 +29,26 @@ else
   regex="^${version_requested}$"
 fi
 
-[ -d "${TGENV_ROOT}/versions" ] \
-  || error_and_die "No versions of terragrunt installed. Please install one with: tgenv install"
-
 version="$(\ls "${TGENV_ROOT}/versions" \
   | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
   | grep -e "${regex}" \
   | head -n 1
 )"
 
-[ -n "${version}" ] || error_and_die "No installed versions of terragrunt matched '${version_requested}'"
+if [ -z "${version}" ]; then
+  if [ "${TGENV_AUTO_INSTALL:-true}" == "true" ]; then
+    info "version '${version_requested}' is not installed. Installing now as TGENV_AUTO_INSTALL==true"
+    tgenv-install "${version_requested}"
+    version="$(\ls "${TGENV_ROOT}/versions" \
+      | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+      | grep -e "${regex}" \
+      | head -n 1
+    )"
+    [ -n "${version}" ] || error_and_die "Installation of '${version_requested}' succeeded but version not found afterwards"
+  else
+    error_and_die "No installed versions of terragrunt matched '${version_requested}'. Set TGENV_AUTO_INSTALL=true to install automatically or install one with: tgenv install"
+  fi
+fi
 
 target_path="${TGENV_ROOT}/versions/${version}"
 [ -f "${target_path}/terragrunt" ] \


### PR DESCRIPTION
## Why? 🤔

We need this change because…the script doesn't even ever consider the `TGENV_AUTO_INSTALL` env var.

## What? :hammer_and_wrench:
This enables the proper respect of said env var.

Fixes #47 

Please add a summary for this pull requests
Adds the consideration of the env var like it is expected. With no value set in the shell, it now auto-installs. And setting it to `false` also results in the standard error of it not existing and how to fix it.

## Additional Links 🌐

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets -->


