### PR TITLE
fix: corrige deploy do MkDocs no GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'mkdocs.yml'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ versions/
 
 # MkDocs build output
 site/
+docs/site/


### PR DESCRIPTION
## Why? 🤔

The Mkdocs sites not worked after last deploy.

## What? :hammer_and_wrench:

- Changes GitHub Pages source from legacy (gh-pages branch) to GitHub Actions via API (build_type=workflow)
- Adds the `main` branch to the deployment branch policies for the `github-pages` environment via API
- Adds `mkdocs.yml` to the trigger paths for the `deploy-docs.yml` workflow
- Adds `docs/site/` to `.gitignore` to avoid tracking the generated build


